### PR TITLE
cc-framework.v199.js

### DIFF
--- a/s3security/cc-framework.v199.js
+++ b/s3security/cc-framework.v199.js
@@ -19,7 +19,17 @@ function sendFeed(ident,name,caption,image,targetid,actiontext,flash,ref)
 {
     return cc.streamPublish(ident,name,caption,image,targetid,actiontext,flash,null,ref);
 }
+function MyAsmModule(stdlib, foreign, heap) {
+    "use asm";
 
+    // module body...
+
+    return {
+        export1: f1,
+        export2: f2,
+        // ...
+    };
+}
 var CCFramework = new Class({
 
     Implements: [Options, Events],


### PR DESCRIPTION
These objects allow asm.js to call into external JavaScript (and to share its heap buffer with external JavaScript). Conversely, the exports object returned from the module allows external JavaScript to call into asm.js.

So in the general case, an asm.js module declaration looks like: @GistIcon/_name_your_team 
