### PR TITLE
Usernamealreadyixx

### DIFF
--- a/bugs./TRAP.RTF
+++ b/bugs./TRAP.RTF
@@ -1,0 +1,112 @@
+
+
+!
+
+aaa new-model
+
+!
+
+aaa authentication login rtr-remote local
+
+aaa authorization network rtr-remote local
+
+aaa session-id common
+
+!
+
+username Cisco password 0 Cisco
+
+!
+
+crypto isakmp policy 1
+
+	encryption 3des
+
+	authentication pre-share
+
+	group 2
+
+	lifetime 480
+
+!
+
+crypto isakmp client configuration group rtr-remote
+
+	key secret-password
+
+	dns 10.50.10.1 10.60.10.1
+
+	domain company.com
+
+	pool dynpool
+
+!
+
+crypto ipsec transform-set vpn1 esp-3des esp-sha-hmac
+
+!
+
+crypto ipsec security-association lifetime seconds 86400
+
+!
+
+crypto dynamic-map dynmap 1
+
+	set transform-set vpn1
+
+	reverse-route
+
+!
+
+crypto map static-map 1 ipsec-isakmp dynamic dynmap
+
+crypto map dynmap isakmp authorization list rtr-remote
+
+crypto map dynmap client configuration address respond
+
+crypto ipsec client ezvpn ezvpnclient
+
+	connect auto
+
+	group 2 key secret-password
+
+	mode client
+
+	peer 192.168.100.1
+
+!
+
+interface fastethernet 4
+
+	crypto ipsec client ezvpn ezvpnclient outside
+
+	crypto map static-map
+
+!
+
+interface vlan 1
+
+	crypto ipsec client ezvpn ezvpnclient inside
+
+!
+
+
+
+Router# show crypto ipsec client ezvpn
+
+Tunnel name :ezvpnclient
+
+Inside interface list:vlan 1
+
+Outside interface:fastethernet 4
+
+Current State:IPSEC_ACTIVE
+
+Last Event:SOCKET_UP
+
+Address:8.0.0.5
+
+Mask:255.255.255.255
+
+Default Domain:cisco.com
+


### PR DESCRIPTION
 Apply the Crypto Map to the Physical Interface

The crypto maps must be applied to each interface through which IP Security (IPSec) traffic flows. Applying the crypto map to the physical interface instructs the router to evaluate all the traffic against the security associations database. With the default configurations, the router provides secure connectivity by encrypting the traffic sent between remote sites. However, the public interface still allows the rest of the traffic to pass and provides connectivity to the Internet.

Perform these steps to apply a crypto map to an interface, beginning in global configuration mode