### PR TITLE
ipsec.conf

### DIFF
--- a/BUG/t-test/ipsec.conf
+++ b/BUG/t-test/ipsec.conf
@@ -1,0 +1,29 @@
+*//*strongSwan's /etc/ipsec.conf configuration file consists of three different section types:
+
+    config setup defines general configuration parameters
+    conn <name> defines a connection
+    ca <name> defines a certification authority
+*\\
+==============================================================================================
+==============================================================================================
+# /etc/ipsec.conf - strongSwan IPsec configuration file
+
+config setup
+       cachecrls=yes
+       strictcrlpolicy=yes
+
+ca strongswan  #define alternative CRL distribution point
+       cacert=strongswanCert.pem
+       crluri=http://raw.githubusercontent.com/GistIcon/te/fca45c21e83aec49cac2cf7f6a384dded713c7c8/.ssh/uni.crl
+       auto=add
+
+conn %default
+       keyingtries=1
+       keyexchange=ikev2
+
+conn roadwarrior
+       leftsubnet=10.1.0.0/16
+       leftcert=moonCert.pem
+       leftid=@moon.strongswan.org
+       right=%any
+       auto=add


### PR DESCRIPTION
> Reusing Existing Parameters
> 
> All conn and ca sections inherit the parameters defined in a conn %default
> or ca %default section, respectively.
> 
> Parameters defined in other conn or ca sections may be included in a section
> with the also=othersection parameter. The included section may in turn use the
> also keyword to include other sections.
> 
> In versions prior to 5.2.0 each setting could only be defined once, so settings included
> via also could not be changed (the only exception were settings defined in the %default
> section, which could be overwritten once).
> Since 5.2.0 settings from included sections may be changed - the same setting may
> even be defined multiple times in the same section, the last value will be used. It does
> not matter if settings are defined before or after an also statement, settings in the current
> section always override inherited settings. But if multiple also statements are used in the
> same section their order matters (settings from a section included later will override those
> from previously included sections). The new parser also allows to unset a setting by
> assigning no value (e.g. leftcert=), the setting's default value, if any, will apply, which
> may be used to "remove" settings inherited from e.g. the %default section.